### PR TITLE
carry bit mistake

### DIFF
--- a/calc_addrs.cl
+++ b/calc_addrs.cl
@@ -344,7 +344,7 @@ bn_uadd_words_c_seq(bn_word *r, bn_word *a, __constant bn_word *b)
 
 #define bn_subb_word(r, a, b, t, c) do {	\
 		t = a - (b + c);		\
-		c = (!(a) && c) ? 1 : 0;	\
+		c = ((a==b) && c) ? 1 : 0;	\
 		c |= (a < b) ? 1 : 0;		\
 		r = t;				\
 	} while (0)


### PR DESCRIPTION
if a=b and c=1 then a-(b+c)=-c=BN_WORDMAX(0xffffffff)
carry bit should be set c=1
That particular mistake happen very rare.